### PR TITLE
Document and validate the neural-network archive

### DIFF
--- a/.github/workflows/repository-hygiene.yml
+++ b/.github/workflows/repository-hygiene.yml
@@ -1,0 +1,24 @@
+name: Repository Hygiene
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repository-hygiene-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Validate preserved archive
+        run: python3 scripts/check_repository.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Repository guidance
+
+## Purpose
+
+This repository is a historical TensorFlow notebook, dataset, and SavedModel
+archive. It is not a current training pipeline or deployable inference system.
+
+## Canonical command
+
+```sh
+python3 scripts/check_repository.py
+```
+
+The validator uses only the Python standard library. It must not execute a
+notebook, import TensorFlow, deserialize a model, or contact an external source.
+
+## Working rules
+
+- Preserve notebooks, saved outputs, and SavedModel directories as historical
+  evidence unless a task explicitly authorizes artifact migration.
+- Never use the archived models for consequential decisions or expose them as
+  a production service.
+- Treat all CSV files as unverified third-party snapshots with incomplete
+  rights and lineage evidence.
+- Do not add live data acquisition or model loading to tests or CI.
+- A maintained successor needs a reproducible dependency lock, explicit data
+  splits, leakage/fairness/calibration evaluation, lineage, and a model card.
+- Stage explicit files, preserve unrelated artifacts, and run the canonical
+  command before opening or updating a pull request.

--- a/README.md
+++ b/README.md
@@ -1,37 +1,90 @@
-# Neural Network Charity Analysis
+# Neural Network Charity Analysis Archive
 
-> Creating a binary classifier that is capable of predicting whether applicants will be successful if funded by Alphabet Soup.
+This repository preserves a 2021 collection of TensorFlow/Keras learning
+notebooks. Its primary exercise trains a binary classifier for the historical
+`IS_SUCCESSFUL` field in a charity-applicant dataset; supporting notebooks
+explore preprocessing and tabular neural-network concepts on other snapshots.
 
-## Overview of Project
+## Project status
 
-Preprocessing the data for the neural network, Compile,train and evaluate the model & finally optimizing the model.
+This is a **historical learning archive**, not a maintained model, inference
+service, current charity dataset, or reproducible training pipeline. The
+repository has no dependency manifest, lockfile, environment export, model
+card, automated training job, or held-out evaluation contract.
 
-## Results
+Saved notebook outputs and 19 TensorFlow SavedModel directories are retained as
+historical artifacts. They have not been loaded or evaluated on a current
+TensorFlow runtime. Do not treat a saved metric, chart, or model directory as
+evidence of present-day accuracy, fairness, calibration, or production fitness.
 
-### Data Preprocessing
-After looking at the data, I established that the target variable is the "IS_SUCCESSFUL" column. I then removed the "EIN" and "NAME" columns as they did not offer any relevant data that could help the model perform better. The remaining columns became the features for the model.
+## Repository map
 
-### Compiling, Training, and Evaluating the Model
-For my first attempt at compiling a neuron network consisted of 8 neurons in the first layer and 6 in the second. Both layers had relu activation functions and the output layer had a sigmoid activation function. I started with these parameters as relu does better with nonlinear data, and two layers allows for a second layer to reweight the inputs from the first layer. Here are the preformance metrics of this model.
+| Path | Historical role |
+| --- | --- |
+| `AlphabetSoupCharity.ipynb` | Baseline charity-applicant preprocessing and classifier exercise |
+| `AlphabetSoupCharity-Optimzation.ipynb` | Historical optimization experiments; the filename typo is preserved for traceability |
+| `01-Keras-Intro.ipynb` | Introductory Keras exercises |
+| `02-Ramen-Ratings.ipynb` | Categorical preprocessing exercise |
+| `03-Standardize.ipynb` | Feature-standardization exercise |
+| `04-DeepLearning-Tabular.ipynb` | Tabular attrition-classification exercise |
+| `data/` | Four third-party CSV snapshots used by the notebooks |
+| `models/` | Nineteen preserved TensorFlow SavedModel directory trees |
+| `resources/` | Historical accuracy and loss charts |
+| `scripts/check_repository.py` | Dependency-free structural validation; it never imports TensorFlow or loads a model |
 
-### Charts
+## Validate the archive
 
-## Summary
+Run the complete repository gate with Python 3.11 or newer:
 
+```sh
+python3 scripts/check_repository.py
+```
 
+The validator:
 
-## Todo Checklist
+- parses all six notebooks as notebook-format JSON without executing cells;
+- verifies the four committed CSV schemas and non-empty data rows;
+- checks the exact inventory and file structure of all 19 SavedModel artifacts;
+- rejects pickle, joblib, and HDF5 model formats from this bounded archive; and
+- enforces a 10 MiB per-file ceiling so artifact growth is reviewed explicitly.
 
-A helpful checklist to gauge how your README is coming on what I would like to finish:
+A passing gate proves structural integrity only. It does not deserialize a
+model, reproduce training, validate saved outputs, or establish rights to use
+the datasets.
 
-- [ ] Improve the Data Processing.
+## Safety and evaluation boundary
 
-## Contributing
+Serialized models are executable-computation artifacts. Load them only in an
+isolated environment after reviewing their origin and framework compatibility.
+Do not expose these models through an API or use their outputs for funding,
+employment, eligibility, or other consequential decisions.
 
-Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+A maintained successor would need, at minimum, a pinned and scanned dependency
+graph, an explicit train/validation/test split, reproducible preprocessing,
+data-version and feature lineage, leakage checks, subgroup and calibration
+evaluation, a model card, and a human-reviewed use policy.
 
-Please make sure to update tests as appropriate.
+## Data rights and provenance
+
+The CSV files are historical third-party snapshots. Their exact upstream
+versions, retrieval dates, licenses, and redistribution permissions are not
+sufficiently documented here. Access to a dataset is not permission to collect,
+persist, model, or republish it.
+
+Before reuse, establish file-level provenance and current terms, then validate
+that the proposed use is permitted. Tests and CI must remain offline and use
+only the committed archive or synthetic fixtures.
+
+## Historical charts
+
+![Historical model loss](resources/loss.png)
+
+![Historical model accuracy](resources/accuracy.png)
+
+These images are saved outputs from the original exercise, not a current model
+evaluation.
 
 ## License
 
-[MIT](https://choosealicense.com/licenses/mit/)
+Repository-authored material is available under the [MIT License](LICENSE).
+That license does not grant rights to third-party datasets or model inputs.

--- a/scripts/check_repository.py
+++ b/scripts/check_repository.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Validate the neural-network archive without executing or loading artifacts."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAX_TRACKED_FILE_BYTES = 10 * 1024 * 1024
+NOTEBOOKS = (
+    "01-Keras-Intro.ipynb",
+    "02-Ramen-Ratings.ipynb",
+    "03-Standardize.ipynb",
+    "04-DeepLearning-Tabular.ipynb",
+    "AlphabetSoupCharity-Optimzation.ipynb",
+    "AlphabetSoupCharity.ipynb",
+)
+CSV_SCHEMAS = {
+    "data/HR-Employee-Attrition.csv": (
+        "Age",
+        "Attrition",
+        "BusinessTravel",
+        "DailyRate",
+        "Department",
+        "DistanceFromHome",
+        "Education",
+        "EducationField",
+        "EmployeeCount",
+        "EmployeeNumber",
+        "EnvironmentSatisfaction",
+        "Gender",
+        "HourlyRate",
+        "JobInvolvement",
+        "JobLevel",
+        "JobRole",
+        "JobSatisfaction",
+        "MaritalStatus",
+        "MonthlyIncome",
+        "MonthlyRate",
+        "NumCompaniesWorked",
+        "Over18",
+        "OverTime",
+        "PercentSalaryHike",
+        "PerformanceRating",
+        "RelationshipSatisfaction",
+        "StandardHours",
+        "StockOptionLevel",
+        "TotalWorkingYears",
+        "TrainingTimesLastYear",
+        "WorkLifeBalance",
+        "YearsAtCompany",
+        "YearsInCurrentRole",
+        "YearsSinceLastPromotion",
+        "YearsWithCurrManager",
+    ),
+    "data/charity_data.csv": (
+        "EIN",
+        "NAME",
+        "APPLICATION_TYPE",
+        "AFFILIATION",
+        "CLASSIFICATION",
+        "USE_CASE",
+        "ORGANIZATION",
+        "STATUS",
+        "INCOME_AMT",
+        "SPECIAL_CONSIDERATIONS",
+        "ASK_AMT",
+        "IS_SUCCESSFUL",
+    ),
+    "data/hr_dataset.csv": (
+        "Satisfaction_Level",
+        "Num_Projects",
+        "Time_Spent",
+        "Num_Promotions",
+    ),
+    "data/ramen-ratings.csv": (
+        "Review #",
+        "Brand",
+        "Variety",
+        "Style",
+        "Country",
+        "Stars",
+        "Top Ten",
+    ),
+}
+MODEL_DIRECTORIES = (
+    "models/model-001",
+    "models/model-002",
+    "models/model-005",
+    "models/model-007",
+    "models/model-009",
+    "models/model-010",
+    "models/model-011",
+    "models/model-012",
+    "models/model-013",
+    "models/model-014",
+    "models/model-015",
+    "models/model-017",
+    "models/model-019",
+    "models/model-020",
+    "models/model-023",
+    "models/model-024",
+    "models/model-034",
+    "models/model-083",
+    "models/model-checkpoints-color/model",
+)
+DISALLOWED_SERIALIZED_SUFFIXES = {".h5", ".hdf5", ".joblib", ".pickle", ".pkl"}
+
+
+class ValidationError(RuntimeError):
+    """Raised when a repository invariant is not satisfied."""
+
+
+def load_notebook(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise ValidationError(f"missing notebook: {path.relative_to(ROOT)}")
+    try:
+        notebook = json.loads(path.read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"invalid notebook JSON in {path.name}: {exc}") from exc
+    if not isinstance(notebook, dict) or notebook.get("nbformat") != 4:
+        raise ValidationError(f"{path.name} is not notebook format 4")
+    cells = notebook.get("cells")
+    if not isinstance(cells, list) or not cells:
+        raise ValidationError(f"{path.name} has no notebook cells")
+    return notebook
+
+
+def validate_csv(relative_path: str, expected_header: tuple[str, ...]) -> int:
+    path = ROOT / relative_path
+    if not path.is_file():
+        raise ValidationError(f"missing CSV snapshot: {relative_path}")
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.reader(handle)
+        try:
+            header = tuple(next(reader))
+            next(reader)
+        except StopIteration as exc:
+            raise ValidationError(f"CSV snapshot has no data rows: {relative_path}") from exc
+    if header != expected_header:
+        raise ValidationError(f"unexpected CSV schema in {relative_path}: {header!r}")
+    return path.stat().st_size
+
+
+def validate_model_directory(relative_path: str) -> None:
+    directory = ROOT / relative_path
+    required = (
+        directory / "saved_model.pb",
+        directory / "variables" / "variables.index",
+        directory / "variables" / "variables.data-00000-of-00001",
+    )
+    missing = [path.relative_to(ROOT) for path in required if not path.is_file()]
+    if missing:
+        raise ValidationError(
+            f"incomplete SavedModel {relative_path}: "
+            + ", ".join(str(path) for path in missing)
+        )
+
+
+def validate_inventory_and_sizes() -> None:
+    discovered_models = tuple(
+        sorted(
+            str(path.parent.relative_to(ROOT))
+            for path in (ROOT / "models").rglob("saved_model.pb")
+        )
+    )
+    if discovered_models != tuple(sorted(MODEL_DIRECTORIES)):
+        raise ValidationError(
+            "SavedModel inventory changed; review and update the explicit contract"
+        )
+
+    for path in ROOT.rglob("*"):
+        if not path.is_file() or ".git" in path.parts:
+            continue
+        if path.suffix.casefold() in DISALLOWED_SERIALIZED_SUFFIXES:
+            raise ValidationError(
+                f"unexpected serialized model format: {path.relative_to(ROOT)}"
+            )
+        size = path.stat().st_size
+        if size > MAX_TRACKED_FILE_BYTES:
+            raise ValidationError(
+                f"{path.relative_to(ROOT)} is {size} bytes; limit is {MAX_TRACKED_FILE_BYTES}"
+            )
+
+
+def main() -> int:
+    try:
+        validate_inventory_and_sizes()
+        notebook_results = []
+        for name in NOTEBOOKS:
+            notebook = load_notebook(ROOT / name)
+            notebook_results.append((name, len(notebook["cells"])))
+        csv_sizes = {
+            path: validate_csv(path, schema) for path, schema in CSV_SCHEMAS.items()
+        }
+        for path in MODEL_DIRECTORIES:
+            validate_model_directory(path)
+    except ValidationError as exc:
+        print(f"archive validation failed: {exc}", file=sys.stderr)
+        return 1
+
+    print("archive validation passed")
+    for name, cell_count in notebook_results:
+        print(f"- {name}: notebook format 4, {cell_count} cells")
+    print(f"- CSV snapshots: {len(csv_sizes)} expected schemas")
+    print(f"- TensorFlow SavedModel artifacts: {len(MODEL_DIRECTORIES)} complete")
+    print("- model deserialization: not performed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- replace the incomplete course README with an accurate historical TensorFlow archive and evaluation boundary
- document the six notebooks, four third-party CSV snapshots, 19 SavedModel directories, non-reproducible environment, model-loading risk, and data-rights requirements
- add a dependency-free validator for notebook JSON, CSV schemas, exact SavedModel structure, unsafe serialized formats, and per-file size bounds
- add a pinned least-privilege GitHub Actions gate and repository-local contributor guidance

## Validation

- `python3 scripts/check_repository.py`
  - six notebook-format-4 files parsed without execution
  - four expected CSV schemas verified
  - 19 complete TensorFlow SavedModel directory structures verified without deserialization
- `python3 -m py_compile scripts/check_repository.py`
- `git diff --check`

## Evidence boundary

The validator does not import TensorFlow, load a model, execute notebooks, reproduce training, validate saved metrics, or establish rights to the datasets. The archived models remain unsuitable for consequential or production use.